### PR TITLE
dynamically determine host IP

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -65,9 +65,10 @@ if [[ -n "${PUBLIC_HOST_ADDR}" && -n "${PUBLIC_HOST_PORT}" ]]; then
     echo "====REMOTE FINGERPRINT===="
     cat ${KNOWN_HOSTS}
     echo "====REMOTE FINGERPRINT===="
-
+    localhostIP=$(/sbin/ip route|awk '/default/ { print $3 }')
+    echo "hosts IP (according to /sbin/ip route) is: ${localhostIP}"
     echo "=> Setting up the reverse ssh tunnel"
-    sshpass -p ${ROOT_PASS} autossh -M 0 -NgR 1080:localhost:${PROXY_PORT} root@${PUBLIC_HOST_ADDR} -p ${PUBLIC_HOST_PORT}
+    sshpass -p ${ROOT_PASS} autossh -M 0 -NgR 1080:${localhostIP}:${PROXY_PORT} root@${PUBLIC_HOST_ADDR} -p ${PUBLIC_HOST_PORT}
 else
     echo "=> Running in public host mode"
     if [ ! -f /.root_pw_set ]; then


### PR DESCRIPTION
When trying to expose a post running on another docker container requires the IP address of the host instead of localhost.  
Dynamically determined the host IP address and used that for the port forwarding